### PR TITLE
Remove group name click-to-edit behavior

### DIFF
--- a/src/components/GroupedListSection.tsx
+++ b/src/components/GroupedListSection.tsx
@@ -347,9 +347,8 @@ export function GroupedListSection({
                     </span>
                   )}
                   <span 
-                    className="text-sm font-semibold text-gray-800 dark:text-gray-200 truncate cursor-pointer hover:text-gray-900 dark:hover:text-gray-100 transition-colors"
+                    className="text-sm font-semibold text-gray-800 dark:text-gray-200 truncate"
                     title={group.name}
-                    onClick={() => setEditingGroup(true)}
                   >
                     {group.name}
                   </span>


### PR DESCRIPTION
This pull request makes a small UI change to the `GroupedListSection` component. The change removes the ability to click on a group's name to trigger editing, likely to prevent accidental edits or simplify interaction.

* Removed the `onClick` handler from the group name, so clicking the name no longer sets the editing state in `GroupedListSection.tsx`.Eliminated the onClick handler from the group name span, disabling the ability to trigger editing by clicking the group name. This change may be intended to prevent accidental edits or to move editing functionality elsewhere.

Closes #20 