### PR TITLE
Add group icon override feature for lists

### DIFF
--- a/src/components/GroupEditModal.tsx
+++ b/src/components/GroupEditModal.tsx
@@ -1,10 +1,11 @@
 import { useState, useEffect } from 'react';
-import { X, Smile } from 'lucide-react';
+import { X, Smile, Eye, EyeOff } from 'lucide-react';
 import { useTaskStore } from '../stores/taskStore.ts';
 import { Button } from './ui/Button.tsx';
 import { Input } from './ui/Input.tsx';
 import { EmojiPicker } from './EmojiPicker.tsx';
 import { extractFirstEmoji, removeFirstEmoji } from '../utils/emojiUtils.ts';
+import { cn } from '../utils/cn.ts';
 
 interface GroupEditModalProps {
   isOpen: boolean;
@@ -17,6 +18,7 @@ export function GroupEditModal({ isOpen, onClose }: GroupEditModalProps) {
   // Form state
   const [name, setName] = useState('');
   const [emoji, setEmoji] = useState('');
+  const [overrideListIcons, setOverrideListIcons] = useState(false);
   const [showEmojiPicker, setShowEmojiPicker] = useState(false);
 
   // Reset form when modal opens/closes
@@ -24,6 +26,7 @@ export function GroupEditModal({ isOpen, onClose }: GroupEditModalProps) {
     if (isOpen) {
       setName('');
       setEmoji('');
+      setOverrideListIcons(false);
       setShowEmojiPicker(false);
     }
   }, [isOpen]);
@@ -31,7 +34,7 @@ export function GroupEditModal({ isOpen, onClose }: GroupEditModalProps) {
   const handleSave = () => {
     if (!name.trim()) return;
 
-    addGroup(name.trim(), undefined, emoji || undefined);
+    addGroup(name.trim(), color, emoji || undefined, overrideListIcons);
     onClose();
   };
 
@@ -115,6 +118,95 @@ export function GroupEditModal({ isOpen, onClose }: GroupEditModalProps) {
                 />
               </div>
             </div>
+          </div>          {/* Icon Override Setting */}
+          <div className="space-y-3">
+            <label className="text-sm font-medium text-gray-700 dark:text-gray-300">
+              List Icon Override
+            </label>
+            <div className="space-y-3">
+              <div className="flex items-center justify-between p-3 border border-gray-200 dark:border-gray-700 rounded-lg bg-gray-50 dark:bg-gray-900">
+                <div className="flex-1">
+                  <div className="flex items-center gap-2">
+                    {overrideListIcons ? (
+                      <Eye size={16} className="text-green-600 dark:text-green-400" />
+                    ) : (
+                      <EyeOff size={16} className="text-gray-400" />
+                    )}
+                    <span className="font-medium text-gray-900 dark:text-white">
+                      Use group icon for all lists
+                    </span>
+                  </div>
+                  <p className="text-sm text-gray-600 dark:text-gray-400 mt-1">
+                    {overrideListIcons 
+                      ? "All lists in this group will display the group icon instead of their individual icons"
+                      : "Lists will display their individual icons as normal"
+                    }
+                  </p>
+                </div>
+                <label className="flex items-center cursor-pointer">
+                  <input
+                    type="checkbox"
+                    checked={overrideListIcons}
+                    onChange={(e) => setOverrideListIcons(e.target.checked)}
+                    className="sr-only"
+                  />
+                  <div 
+                    className={cn(
+                      "relative w-11 h-6 rounded-full transition-colors duration-200",
+                      overrideListIcons 
+                        ? "bg-blue-600" 
+                        : "bg-gray-300 dark:bg-gray-600"
+                    )}
+                  >
+                    <div 
+                      className={cn(
+                        "absolute top-0.5 left-0.5 w-5 h-5 bg-white rounded-full transition-transform duration-200",
+                        overrideListIcons ? "translate-x-5" : "translate-x-0"
+                      )}
+                    />
+                  </div>
+                </label>
+              </div>
+              
+              {overrideListIcons && !emoji && (
+                <div className="p-3 bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-lg">
+                  <p className="text-sm text-amber-800 dark:text-amber-200">
+                    💡 Add a group icon above to see it applied to all lists in this group
+                  </p>
+                </div>
+              )}
+            </div>
+          </div>
+
+          {/* Icon Override Section */}
+          <div className="space-y-3">
+            <div className="flex items-center justify-between">
+              <div className="flex items-center space-x-2">
+                {overrideListIcons ? <Eye className="h-4 w-4" /> : <EyeOff className="h-4 w-4" />}
+                <span className="text-sm font-medium">Icon Override</span>
+              </div>
+              <button
+                type="button"
+                onClick={() => setOverrideListIcons(!overrideListIcons)}
+                className={cn(
+                  "relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2",
+                  overrideListIcons ? "bg-blue-600" : "bg-gray-200 dark:bg-gray-600"
+                )}
+                role="switch"
+                aria-checked={overrideListIcons}
+              >
+                <span
+                  aria-hidden="true"
+                  className={cn(
+                    "pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out",
+                    overrideListIcons ? "translate-x-5" : "translate-x-0"
+                  )}
+                />
+              </button>
+            </div>
+            <p className="text-xs text-gray-500 dark:text-gray-400">
+              When enabled, this group's icon will override individual list icons within the group
+            </p>
           </div>
 
           {/* Preview */}

--- a/src/components/GroupEditSidebar.tsx
+++ b/src/components/GroupEditSidebar.tsx
@@ -1,0 +1,447 @@
+import { useState, useEffect } from 'react';
+import { X, Smile, Trash2, Eye, EyeOff } from 'lucide-react';
+import type { ListGroup } from '../types/index.ts';
+import { useTaskStore } from '../stores/taskStore.ts';
+import { Button } from './ui/Button.tsx';
+import { Input } from './ui/Input.tsx';
+import { EmojiPicker } from './EmojiPicker.tsx';
+import { cn } from '../utils/cn.ts';
+import { extractFirstEmoji, removeFirstEmoji } from '../utils/emojiUtils.ts';
+
+interface GroupEditSidebarProps {
+  group?: ListGroup;
+  isOpen: boolean;
+  onClose: () => void;
+  mode: 'create' | 'edit';
+}
+
+export function GroupEditSidebar({ group, isOpen, onClose, mode }: GroupEditSidebarProps) {
+  const { addGroup, updateGroup, deleteGroup, getListsInGroup } = useTaskStore();
+  
+  // Form state
+  const [name, setName] = useState(group?.name || '');
+  const [emoji, setEmoji] = useState(group?.emoji || '');
+  const [color, setColor] = useState(group?.color || '#3b82f6');
+  const [overrideListIcons, setOverrideListIcons] = useState(group?.overrideListIcons || false);
+  const [showEmojiPicker, setShowEmojiPicker] = useState(false);
+
+  // Color options
+  const colors = [
+    // Primary blues
+    '#3b82f6', // blue
+    '#1e40af', // blue-800
+    '#0ea5e9', // sky-500
+    '#0284c7', // sky-600
+    
+    // Greens
+    '#10b981', // emerald
+    '#059669', // emerald-600
+    '#84cc16', // lime
+    '#65a30d', // lime-600
+    '#16a34a', // green-600
+    '#15803d', // green-700
+    
+    // Warm colors
+    '#f59e0b', // amber
+    '#d97706', // amber-600
+    '#f97316', // orange
+    '#ea580c', // orange-600
+    '#dc2626', // red-600
+    '#ef4444', // red
+    
+    // Purples & Magentas
+    '#8b5cf6', // violet
+    '#7c3aed', // violet-600
+    '#a855f7', // purple-500
+    '#9333ea', // purple-600
+    '#ec4899', // pink
+    '#db2777', // pink-600
+    '#be185d', // pink-700
+    
+    // Cyans & Teals
+    '#06b6d4', // cyan
+    '#0891b2', // cyan-600
+    '#14b8a6', // teal-500
+    '#0d9488', // teal-600
+    
+    // Neutrals & Earth tones
+    '#6b7280', // gray
+    '#4b5563', // gray-600
+    '#374151', // gray-700
+    '#78716c', // stone-500
+    '#57534e', // stone-600
+    
+    // Additional vibrant colors
+    '#fbbf24', // amber-400
+    '#fb7185', // rose-400
+    '#a78bfa', // violet-400
+    '#34d399', // emerald-400
+    '#60a5fa', // blue-400
+    '#f472b6', // pink-400
+  ];
+
+  // Get lists in this group for preview
+  const groupLists = group ? getListsInGroup(group.id) : [];
+
+  // Reset form when group changes or modal opens/closes
+  useEffect(() => {
+    if (isOpen) {
+      if (group) {
+        setName(group.name);
+        setEmoji(group.emoji || '');
+        setColor(group.color || '#3b82f6');
+        setOverrideListIcons(group.overrideListIcons || false);
+      } else {
+        setName('');
+        setEmoji('');
+        setColor('#3b82f6');
+        setOverrideListIcons(false);
+      }
+      setShowEmojiPicker(false);
+    }
+  }, [isOpen, group]);
+
+  const handleSave = () => {
+    if (!name.trim()) return;
+
+    if (mode === 'create') {
+      addGroup(name.trim(), color, emoji, overrideListIcons);
+    } else if (group) {
+      updateGroup(group.id, {
+        name: name.trim(),
+        emoji,
+        color,
+        overrideListIcons,
+      });
+    }
+
+    onClose();
+  };
+
+  const handleNameChange = (value: string) => {
+    const extractedEmoji = extractFirstEmoji(value);
+    if (extractedEmoji && !emoji) {
+      // If user types an emoji and we don't have one set, extract it
+      setEmoji(extractedEmoji);
+      setName(removeFirstEmoji(value));
+    } else {
+      setName(value);
+    }
+  };
+
+  const handleDelete = () => {
+    if (group && confirm('Are you sure you want to delete this group? Lists will be moved to ungrouped.')) {
+      deleteGroup(group.id, null);
+      onClose();
+    }
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex">
+      {/* Backdrop */}
+      <div 
+        className="flex-1 bg-black bg-opacity-25" 
+        onClick={onClose}
+      />
+      
+      {/* Sidebar */}
+      <div className="w-96 bg-white dark:bg-gray-800 shadow-xl flex flex-col relative overflow-hidden">
+        {/* Color accent line */}
+        {color && (
+          <div 
+            className="absolute top-0 left-0 right-0 h-1 z-10"
+            style={{ backgroundColor: color }}
+          />
+        )}
+        {/* Header */}
+        <div className="flex items-center justify-between p-4 border-b border-gray-200 dark:border-gray-700 relative">
+          {color && (
+            <div 
+              className="absolute inset-0 opacity-5"
+              style={{ 
+                background: `linear-gradient(135deg, ${color} 0%, transparent 80%)`
+              }}
+            />
+          )}
+          <div className="flex items-center gap-3 relative z-10">
+            {color && (
+              <div 
+                className="w-3 h-3 rounded-full shadow-sm"
+                style={{ 
+                  backgroundColor: color,
+                  boxShadow: `0 2px 8px ${color}40`
+                }}
+              />
+            )}
+            <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
+              {mode === 'create' ? 'New Group' : 'Edit Group'}
+            </h2>
+          </div>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={onClose}
+            className="p-2 relative z-10"
+          >
+            <X size={20} />
+          </Button>
+        </div>
+
+        {/* Content */}
+        <div className="flex-1 overflow-y-auto p-6 space-y-6">
+          {/* Group Name and Emoji */}
+          <div className="space-y-4">
+            <div className="flex items-center gap-3">
+              <div className="relative">
+                <Button
+                  variant="ghost"
+                  onClick={() => setShowEmojiPicker(!showEmojiPicker)}
+                  className="h-12 w-12 p-0 text-2xl border-2 border-dashed border-gray-300 dark:border-gray-600 hover:border-gray-400"
+                >
+                  {emoji || <Smile size={20} className="text-gray-400" />}
+                </Button>
+                
+                {showEmojiPicker && (
+                  <EmojiPicker
+                    value={emoji}
+                    onChange={setEmoji}
+                    onClose={() => setShowEmojiPicker(false)}
+                  />
+                )}
+              </div>
+              
+              <div className="flex-1">
+                <Input
+                  value={name}
+                  onChange={(e) => handleNameChange(e.target.value)}
+                  placeholder="Group name"
+                  className="text-lg font-medium"
+                  autoFocus={mode === 'create'}
+                />
+              </div>
+            </div>
+          </div>
+
+          {/* Color Selection */}
+          <div className="space-y-3">
+            <label className="text-sm font-medium text-gray-700 dark:text-gray-300">
+              Color Theme
+            </label>
+            <div className="grid grid-cols-8 gap-2">
+              {colors.map((colorOption) => (
+                <button
+                  key={colorOption}
+                  onClick={() => setColor(colorOption)}
+                  className={cn(
+                    'w-10 h-10 rounded-lg border-2 transition-all duration-200 relative overflow-hidden group',
+                    color === colorOption
+                      ? 'border-gray-900 dark:border-white scale-110 shadow-lg'
+                      : 'border-gray-300 dark:border-gray-600 hover:scale-105 hover:border-gray-400'
+                  )}
+                  style={{ 
+                    backgroundColor: colorOption,
+                    boxShadow: color === colorOption 
+                      ? `0 4px 12px ${colorOption}40` 
+                      : `0 2px 4px ${colorOption}20`
+                  }}
+                >
+                  {/* Inner highlight */}
+                  <div 
+                    className="absolute inset-1 rounded-md bg-white/20 opacity-0 group-hover:opacity-100 transition-opacity"
+                  />
+                  {/* Selection indicator */}
+                  {color === colorOption && (
+                    <div className="absolute inset-0 flex items-center justify-center">
+                      <div className="w-3 h-3 bg-white rounded-full shadow-sm flex items-center justify-center">
+                        <svg className="w-2 h-2 text-gray-800" fill="currentColor" viewBox="0 0 20 20">
+                          <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
+                        </svg>
+                      </div>
+                    </div>
+                  )}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* Icon Override Setting */}
+          <div className="space-y-3">
+            <label className="text-sm font-medium text-gray-700 dark:text-gray-300">
+              List Icon Override
+            </label>
+            <div className="space-y-3">
+              <div className="flex items-center justify-between p-3 border border-gray-200 dark:border-gray-700 rounded-lg bg-gray-50 dark:bg-gray-900">
+                <div className="flex-1">
+                  <div className="flex items-center gap-2">
+                    {overrideListIcons ? (
+                      <Eye size={16} className="text-green-600 dark:text-green-400" />
+                    ) : (
+                      <EyeOff size={16} className="text-gray-400" />
+                    )}
+                    <span className="font-medium text-gray-900 dark:text-white">
+                      Use group icon for all lists
+                    </span>
+                  </div>
+                  <p className="text-sm text-gray-600 dark:text-gray-400 mt-1">
+                    {overrideListIcons 
+                      ? "All lists in this group will display the group icon instead of their individual icons"
+                      : "Lists will display their individual icons as normal"
+                    }
+                  </p>
+                </div>
+                <label className="flex items-center cursor-pointer">
+                  <input
+                    type="checkbox"
+                    checked={overrideListIcons}
+                    onChange={(e) => setOverrideListIcons(e.target.checked)}
+                    className="sr-only"
+                  />
+                  <div 
+                    className={cn(
+                      "relative w-11 h-6 rounded-full transition-colors duration-200",
+                      overrideListIcons 
+                        ? "bg-blue-600" 
+                        : "bg-gray-300 dark:bg-gray-600"
+                    )}
+                  >
+                    <div 
+                      className={cn(
+                        "absolute top-0.5 left-0.5 w-5 h-5 bg-white rounded-full transition-transform duration-200",
+                        overrideListIcons ? "translate-x-5" : "translate-x-0"
+                      )}
+                    />
+                  </div>
+                </label>
+              </div>
+              
+              {overrideListIcons && !emoji && (
+                <div className="p-3 bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-lg">
+                  <p className="text-sm text-amber-800 dark:text-amber-200">
+                    💡 Add a group icon above to see it applied to all lists in this group
+                  </p>
+                </div>
+              )}
+            </div>
+          </div>
+
+          {/* Preview */}
+          <div className="space-y-3">
+            <label className="text-sm font-medium text-gray-700 dark:text-gray-300">
+              Preview
+            </label>
+            <div 
+              className="p-4 border rounded-xl bg-gray-50 dark:bg-gray-900 border-gray-200 dark:border-gray-700 relative overflow-hidden"
+              style={{
+                borderLeft: `4px solid ${color}`,
+                backgroundColor: `${color}08`
+              }}
+            >
+              {/* Accent line */}
+              <div 
+                className="absolute left-0 top-0 bottom-0 w-1"
+                style={{ backgroundColor: color }}
+              />
+              <div className="space-y-3 relative z-10">
+                {/* Group header */}
+                <div className="flex items-center gap-3">
+                  <div 
+                    className="w-4 h-4 rounded-full shadow-sm"
+                    style={{ 
+                      backgroundColor: color,
+                      boxShadow: `0 2px 8px ${color}40`
+                    }}
+                  />
+                  {emoji && <span className="text-lg">{emoji}</span>}
+                  <span className="font-medium text-gray-900 dark:text-white">
+                    {name || 'Group name'}
+                  </span>
+                </div>
+                
+                {/* Sample lists in group */}
+                {groupLists.length > 0 && (
+                  <div className="ml-7 space-y-2">
+                    {groupLists.slice(0, 3).map((list) => (
+                      <div key={list.id} className="flex items-center gap-2 text-sm">
+                        <span className="text-xs">
+                          {overrideListIcons && emoji ? emoji : (list.emoji || '📝')}
+                        </span>
+                        <span className="text-gray-700 dark:text-gray-300">
+                          {list.name}
+                        </span>
+                      </div>
+                    ))}
+                    {groupLists.length > 3 && (
+                      <div className="text-xs text-gray-500 dark:text-gray-400 ml-4">
+                        +{groupLists.length - 3} more lists
+                      </div>
+                    )}
+                  </div>
+                )}
+                
+                {/* Show sample lists if creating new group */}
+                {mode === 'create' && (
+                  <div className="ml-7 space-y-2">
+                    <div className="flex items-center gap-2 text-sm">
+                      <span className="text-xs">
+                        {overrideListIcons && emoji ? emoji : '📝'}
+                      </span>
+                      <span className="text-gray-700 dark:text-gray-300">
+                        Sample List 1
+                      </span>
+                    </div>
+                    <div className="flex items-center gap-2 text-sm">
+                      <span className="text-xs">
+                        {overrideListIcons && emoji ? emoji : '✅'}
+                      </span>
+                      <span className="text-gray-700 dark:text-gray-300">
+                        Sample List 2
+                      </span>
+                    </div>
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* Footer */}
+        <div className="p-4 border-t border-gray-200 dark:border-gray-700">
+          <div className="flex justify-between items-center">
+            <div>
+              {mode === 'edit' && group && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={handleDelete}
+                  className="text-red-500 hover:text-red-700 flex items-center gap-2"
+                >
+                  <Trash2 size={16} />
+                  Delete group
+                </Button>
+              )}
+            </div>
+            
+            <div className="flex gap-2">
+              <Button
+                variant="secondary"
+                size="sm"
+                onClick={onClose}
+              >
+                Cancel
+              </Button>
+              <Button
+                onClick={handleSave}
+                size="sm"
+                disabled={!name.trim()}
+              >
+                {mode === 'create' ? 'Create group' : 'Save'}
+              </Button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/GroupedListSection.tsx
+++ b/src/components/GroupedListSection.tsx
@@ -15,6 +15,7 @@ import { cn } from '../utils/cn';
 import { useTaskStore } from '../stores/taskStore';
 import type { TaskList, ListGroup } from '../types';
 import { ListEditSidebar } from './ListEditSidebar';
+import { GroupEditSidebar } from './GroupEditSidebar';
 import { getListDisplayInfo, extractFirstEmoji, removeFirstEmoji } from '../utils/emojiUtils';
 import { useContextMenuHandler } from './ui/useContextMenu.ts';
 import { createListContextMenu } from './ui/contextMenus.tsx';
@@ -210,6 +211,7 @@ export function GroupedListSection({
   const [groupName, setGroupName] = useState(group?.name || '');
   const [showAddListModal, setShowAddListModal] = useState(false);
   const [editingList, setEditingList] = useState<TaskList | null>(null);
+  const [showGroupEditSidebar, setShowGroupEditSidebar] = useState(false);
   
   const { 
     toggleGroupCollapsed, 
@@ -375,10 +377,10 @@ export function GroupedListSection({
                 </button>
                 
                 {showGroupMenu && (
-                  <div className="absolute right-0 top-full mt-1 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-md shadow-lg z-50 min-w-[120px]">
+                  <div className="absolute right-0 top-full mt-1 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-md shadow-lg z-40 min-w-[120px]">
                     <button
                       onClick={() => {
-                        setEditingGroup(true);
+                        setShowGroupEditSidebar(true);
                         setShowGroupMenu(false);
                       }}
                       className="w-full px-3 py-2 text-left text-sm hover:bg-gray-100 dark:hover:bg-gray-700 flex items-center gap-2"
@@ -441,6 +443,16 @@ export function GroupedListSection({
           isOpen={!!editingList}
           mode="edit"
           onClose={() => setEditingList(null)}
+        />
+      )}
+      
+      {/* Group Edit Sidebar */}
+      {group && (
+        <GroupEditSidebar
+          group={group}
+          isOpen={showGroupEditSidebar}
+          onClose={() => setShowGroupEditSidebar(false)}
+          mode="edit"
         />
       )}
     </div>

--- a/src/components/TaskItem.tsx
+++ b/src/components/TaskItem.tsx
@@ -20,7 +20,7 @@ interface TaskItemProps {
 }
 
 export function TaskItem({ task, isDragEnabled = false, isOver = false, isDragging: providedIsDragging = false }: TaskItemProps) {
-  const { toggleTask, toggleImportant, toggleSubTask, lists, deleteTask, addTask, toggleMyDay, togglePin, toggleGlobalPin } = useTaskStore();
+  const { toggleTask, toggleImportant, toggleSubTask, lists, deleteTask, addTask, toggleMyDay, togglePin, toggleGlobalPin, getGroupForList } = useTaskStore();
   
   // Only use sortable hook if drag is enabled
   const sortable = useSortable({ 
@@ -44,6 +44,10 @@ export function TaskItem({ task, isDragEnabled = false, isOver = false, isDraggi
   // Get the list this task belongs to
   const taskList = lists.find(list => list.id === task.listId);
   const listColor = taskList?.color;
+
+  // Check if group has icon override enabled
+  const group = taskList ? getGroupForList(taskList.id) : null;
+  const displayEmoji = (group?.overrideListIcons && group.emoji) ? group.emoji : taskList?.emoji;
 
   const handleToggleComplete = () => {
     toggleTask(task.id);
@@ -207,8 +211,8 @@ export function TaskItem({ task, isDragEnabled = false, isOver = false, isDraggi
               {/* Custom list name tag - positioned close to the color border */}
               {taskList && !taskList.isSystem && (
                 <div className="flex items-center gap-1 flex-shrink-0 mt-0.5">
-                  {taskList.emoji && (
-                    <span className="text-xs">{taskList.emoji}</span>
+                  {displayEmoji && (
+                    <span className="text-xs">{displayEmoji}</span>
                   )}
                   <span 
                     className="text-xs font-medium px-2 py-0.5 rounded-full border whitespace-nowrap"

--- a/src/components/TaskView.tsx
+++ b/src/components/TaskView.tsx
@@ -91,7 +91,7 @@ export function TaskView() {
     <>
       <div className="flex flex-col h-full">
         {/* Header */}
-        <header className="p-6 border-b border-gray-200 dark:border-gray-700 relative overflow-hidden">
+        <header className="p-6 border-b border-gray-200 dark:border-gray-700 relative overflow-visible">
           {isCustomList && currentList?.color && (
             <>
               {/* Color accent line */}

--- a/src/components/ui/ContextMenu.tsx
+++ b/src/components/ui/ContextMenu.tsx
@@ -150,7 +150,7 @@ const ContextMenu = React.forwardRef<HTMLDivElement, ContextMenuProps>(
       <div
         ref={ref}
         className={cn(
-          "fixed z-50 min-w-[200px] bg-white dark:bg-gray-800 rounded-lg shadow-lg border border-gray-200 dark:border-gray-700",
+          "fixed z-40 min-w-[200px] bg-white dark:bg-gray-800 rounded-lg shadow-lg border border-gray-200 dark:border-gray-700",
           "animate-in fade-in-0 zoom-in-95 duration-100"
         )}
         style={{

--- a/src/components/ui/Toast.tsx
+++ b/src/components/ui/Toast.tsx
@@ -181,7 +181,7 @@ export function ToastContainer({
 
   return (
     <div
-      className="fixed top-4 right-4 z-50 flex flex-col gap-2 pointer-events-none"
+      className="fixed top-4 right-4 z-[60] flex flex-col gap-2 pointer-events-none"
       aria-live="polite"
       aria-label="Notifications"
     >

--- a/src/stores/taskStore.ts
+++ b/src/stores/taskStore.ts
@@ -28,7 +28,7 @@ interface TaskStore extends AppState {
   moveListToGroup: (listId: string, groupId: string | null) => void;
   
   // Group actions
-  addGroup: (name: string, color?: string, emoji?: string) => void;
+  addGroup: (name: string, color?: string, emoji?: string, overrideListIcons?: boolean) => void;
   updateGroup: (id: string, updates: Partial<ListGroup>) => void;
   deleteGroup: (id: string, moveListsToGroupId?: string | null) => void;
   reorderGroups: (groupIds: string[]) => void;
@@ -52,6 +52,7 @@ interface TaskStore extends AppState {
   getTaskCountForList: (listId: string) => number;
   getListsInGroup: (groupId: string | null) => TaskList[];
   getGroupedLists: () => { group: ListGroup | null; lists: TaskList[] }[];
+  getGroupForList: (listId: string) => ListGroup | null;
 }
 
 // Default system lists
@@ -719,7 +720,7 @@ export const useTaskStore = create<TaskStore>()((set, get) => {
     },
 
     // Group management actions
-    addGroup: (name: string, color?: string, emoji?: string) => {
+    addGroup: (name: string, color?: string, emoji?: string, overrideListIcons?: boolean) => {
       const newGroup: ListGroup = {
         id: generateId(),
         name,
@@ -727,6 +728,7 @@ export const useTaskStore = create<TaskStore>()((set, get) => {
         color,
         collapsed: false,
         order: get().listGroups.length,
+        overrideListIcons: overrideListIcons || false,
         createdAt: new Date(),
       };
 
@@ -824,6 +826,13 @@ export const useTaskStore = create<TaskStore>()((set, get) => {
       });
 
       return result;
+    },
+
+    getGroupForList: (listId: string) => {
+      const { lists, listGroups } = get();
+      const list = lists.find(l => l.id === listId);
+      if (!list || !list.groupId) return null;
+      return listGroups.find(g => g.id === list.groupId) || null;
     },
   };
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -45,6 +45,7 @@ export interface ListGroup {
   collapsed: boolean;
   order: number;
   createdAt: Date;
+  overrideListIcons?: boolean;
 }
 
 export interface TaskFilter {


### PR DESCRIPTION
This pull request introduces a new feature allowing group icons to override individual list icons within a group. It adds UI controls for this setting in the group edit modal and sidebar, updates the data model and store logic to support the override, and ensures that tasks display the correct icon based on the group setting. Minor adjustments to z-index values in UI components are also included for improved layering.

### Group Icon Override Feature

* Added a `overrideListIcons` property to the `ListGroup` type and integrated it into group creation and editing logic in `taskStore`, enabling groups to enforce their icon across all contained lists. [[1]](diffhunk://#diff-a9ba9cbedd19c9f66d564d2e89912890209b98f0a7ef19187877d2587300e476R48) [[2]](diffhunk://#diff-1bc25ec709da47f95657ea809ef15bb165b96709afaf3eb94cbd4a22c4411235L31-R31) [[3]](diffhunk://#diff-1bc25ec709da47f95657ea809ef15bb165b96709afaf3eb94cbd4a22c4411235L722-R731)
* Implemented UI controls for toggling the icon override in `GroupEditModal` and `GroupEditSidebar`, including descriptive labels, switch controls, and contextual hints for users. [[1]](diffhunk://#diff-7ff0ac41589e67404346706a6cb785d19109e87af701b593a77709eae421668eR21-R37) [[2]](diffhunk://#diff-7ff0ac41589e67404346706a6cb785d19109e87af701b593a77709eae421668eR121-R209)
* Updated task rendering logic in `TaskItem` to display the group icon for tasks when the override is enabled, falling back to the list icon otherwise. [[1]](diffhunk://#diff-d3ac101ffd80b9be0b7e83e7e20cbde310abc1bad67edb9dc5d6ab1ade55066aL23-R23) [[2]](diffhunk://#diff-d3ac101ffd80b9be0b7e83e7e20cbde310abc1bad67edb9dc5d6ab1ade55066aR48-R51) [[3]](diffhunk://#diff-d3ac101ffd80b9be0b7e83e7e20cbde310abc1bad67edb9dc5d6ab1ade55066aL210-R215)
* Added a `getGroupForList` selector to `taskStore` for efficient lookup of a list's parent group and its settings. [[1]](diffhunk://#diff-1bc25ec709da47f95657ea809ef15bb165b96709afaf3eb94cbd4a22c4411235R55) [[2]](diffhunk://#diff-1bc25ec709da47f95657ea809ef15bb165b96709afaf3eb94cbd4a22c4411235R830-R836)

### UI Layering Adjustments

* Tweaked z-index values for context menus and toast notifications to ensure proper stacking order and visibility in the UI. [[1]](diffhunk://#diff-abac910c0b073fe4c33ee5d1e787e16a6f2e343320913317c1bc569ee24a92ccL153-R153) [[2]](diffhunk://#diff-b30c70d0eaef892f71607740ca99cd61e23dbf469267cc7d3007b27daa8a18b1L184-R184) [[3]](diffhunk://#diff-567efd584fde8961a11d9441c7c661720e13809c6a9f612b7798ed49ad16be91L378-R383) [[4]](diffhunk://#diff-d276055dfbf9ae7ab2c3830090ea9fc816a893f7a744e91ae7d9189ef44c28a2L94-R94)Introduces the ability for a group to override individual list icons with the group's icon. Updates UI components to support this setting, adds the GroupEditSidebar, and extends store/types logic to handle the new overrideListIcons property.