### PR TITLE
Remove success toast on task creation

### DIFF
--- a/src/components/QuickAddTaskForm.tsx
+++ b/src/components/QuickAddTaskForm.tsx
@@ -14,7 +14,7 @@ interface QuickAddTaskFormProps {
 
 export function QuickAddTaskForm({ isOpen, onClose, onFullFormRequested, initialTitle = '' }: QuickAddTaskFormProps) {
   const { addTask, currentView, currentListId } = useTaskStore();
-  const { showError, showSuccess } = useToastStore();
+  const { showError } = useToastStore();
   const [title, setTitle] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -54,7 +54,6 @@ export function QuickAddTaskForm({ isOpen, onClose, onFullFormRequested, initial
       // Create the task with minimal data
       addTask(title.trim(), listId);
       
-      showSuccess('Task created', `"${title.trim()}" has been added`);
       setTitle('');
       onClose();
     } catch {

--- a/src/components/TaskView.tsx
+++ b/src/components/TaskView.tsx
@@ -123,7 +123,7 @@ export function TaskView() {
 
   const handleInlineTaskCreate = (title: string) => {
     const { addTask } = useTaskStore.getState();
-    const { showSuccess, showError } = useToastStore.getState();
+    const { showError } = useToastStore.getState();
     
     try {
       // Determine which list to add the task to
@@ -135,8 +135,6 @@ export function TaskView() {
       // Create the task directly
       addTask(title, listId);
       
-      // Show success feedback
-      showSuccess('Task created', `"${title}" has been added`);
     } catch {
       // Show error feedback
       showError('Error', 'Failed to create task. Please try again.');


### PR DESCRIPTION
Eliminates the success notification when a task is created from QuickAddTaskForm and TaskView, leaving only error feedback. This streamlines the user experience by reducing redundant notification
This pull request removes success toast notifications when creating tasks via the quick add form and inline task creation, streamlining the user feedback to only show error notifications when task creation fails.

Feedback handling changes:

* Removed calls to `showSuccess` in both the `QuickAddTaskForm` and `TaskView` components, so users will no longer see a success toast after adding a task. [[1]](diffhunk://#diff-b0922a72769358fa8c3561e45de9103254c3e81cedf4aa8eeb7f8bbca1ea9b3bL57) [[2]](diffhunk://#diff-d276055dfbf9ae7ab2c3830090ea9fc816a893f7a744e91ae7d9189ef44c28a2L138-L139)
* Updated imports and destructuring to exclude `showSuccess` from `useToastStore` in both components. [[1]](diffhunk://#diff-b0922a72769358fa8c3561e45de9103254c3e81cedf4aa8eeb7f8bbca1ea9b3bL17-R17) [[2]](diffhunk://#diff-d276055dfbf9ae7ab2c3830090ea9fc816a893f7a744e91ae7d9189ef44c28a2L126-R126)s.

Closes #27