### PR TITLE
Add lazy loading for modals and markdown editor

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,8 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, Suspense } from 'react';
 import { useTaskStore } from './stores/taskStore.ts';
 import { Sidebar } from './components/Sidebar.tsx';
 import { TaskView } from './components/TaskView.tsx';
-import { GroupEditModal } from './components/GroupEditModal.tsx';
+import { LazyGroupEditModal } from './components/GroupEditModal.tsx';
 import { ContextMenuProvider } from './components/ui/ContextMenu.tsx';
 import { ToastProvider } from './components/ui/ToastProvider.tsx';
 import { cn } from './utils/cn.ts';
@@ -37,10 +37,12 @@ function App() {
         </main>
 
         {/* Group Modal - rendered at root level for proper z-index */}
-        <GroupEditModal
-          isOpen={showAddGroupModal}
-          onClose={() => setShowAddGroupModal(false)}
-        />
+        <Suspense fallback={null}>
+          <LazyGroupEditModal
+            isOpen={showAddGroupModal}
+            onClose={() => setShowAddGroupModal(false)}
+          />
+        </Suspense>
         
         {/* Toast notifications */}
         <ToastProvider />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,15 @@
-import { useEffect, useState, Suspense } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useTaskStore } from './stores/taskStore.ts';
 import { Sidebar } from './components/Sidebar.tsx';
 import { TaskView } from './components/TaskView.tsx';
-import { LazyGroupEditModal } from './components/GroupEditModal.tsx';
+// Create lazy component for GroupEditModal
+const LazyGroupEditModal = React.lazy(() => 
+  import('./components/GroupEditModal.tsx').then(module => ({ 
+    default: module.GroupEditModal 
+  }))
+);
+import { LazyWrapper } from './components/ui/ErrorBoundary.tsx';
+import { ModalLoadingWithTimeout } from './components/ui/LoadingWithTimeout.tsx';
 import { ContextMenuProvider } from './components/ui/ContextMenu.tsx';
 import { ToastProvider } from './components/ui/ToastProvider.tsx';
 import { cn } from './utils/cn.ts';
@@ -37,12 +44,15 @@ function App() {
         </main>
 
         {/* Group Modal - rendered at root level for proper z-index */}
-        <Suspense fallback={null}>
+        <LazyWrapper
+          fallback={showAddGroupModal ? <ModalLoadingWithTimeout message="Loading modal..." /> : null}
+          context="group edit modal"
+        >
           <LazyGroupEditModal
             isOpen={showAddGroupModal}
             onClose={() => setShowAddGroupModal(false)}
           />
-        </Suspense>
+        </LazyWrapper>
         
         {/* Toast notifications */}
         <ToastProvider />

--- a/src/components/GroupEditModal.tsx
+++ b/src/components/GroupEditModal.tsx
@@ -167,9 +167,4 @@ export function GroupEditModal({ isOpen, onClose }: GroupEditModalProps) {
   );
 }
 
-// Lazy-loaded wrapper component
-export const LazyGroupEditModal = React.lazy(() => 
-  import('./GroupEditModal.tsx').then(module => ({ 
-    default: module.GroupEditModal 
-  }))
-);
+

--- a/src/components/GroupEditModal.tsx
+++ b/src/components/GroupEditModal.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import React, { useState, useEffect } from 'react';
 import { X, Smile } from 'lucide-react';
 import { useTaskStore } from '../stores/taskStore.ts';
 import { Button } from './ui/Button.tsx';
@@ -166,3 +166,10 @@ export function GroupEditModal({ isOpen, onClose }: GroupEditModalProps) {
     </div>
   );
 }
+
+// Lazy-loaded wrapper component
+export const LazyGroupEditModal = React.lazy(() => 
+  import('./GroupEditModal.tsx').then(module => ({ 
+    default: module.GroupEditModal 
+  }))
+);

--- a/src/components/TaskDetailSidebar.tsx
+++ b/src/components/TaskDetailSidebar.tsx
@@ -1,10 +1,10 @@
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useState, useEffect, useCallback, useRef, Suspense } from 'react';
 import { X, Star, Calendar, Repeat, FileText, CheckSquare, Sun, Bell, Copy, Pin, Archive, List } from 'lucide-react';
 import type { Task } from '../types/index.ts';
 import { useTaskStore } from '../stores/taskStore.ts';
 import { Button } from './ui/Button.tsx';
 import { Input } from './ui/Input.tsx';
-import { MarkdownEditor } from './ui/MarkdownEditor.tsx';
+import { LazyMarkdownEditor } from './ui/MarkdownEditor.tsx';
 import { DateTimePicker } from './DateTimePicker.tsx';
 import { CategorySelector } from './CategorySelector.tsx';
 import { AutoSaveIndicator } from './ui/AutoSaveIndicator.tsx';
@@ -887,11 +887,17 @@ export function TaskDetailSidebar({ task, isOpen, onClose, mode, initialListId }
                   </div>
                   <span className="font-medium text-base text-gray-900 dark:text-white">Add note</span>
                 </div>
-                <MarkdownEditor
-                  value={notes}
-                  onChange={(value) => setNotes(value)}
-                  placeholder="Add a detailed description or note about this task..."
-                />
+                <Suspense fallback={
+                  <div className="animate-pulse bg-gray-100 dark:bg-gray-700 rounded-lg h-32 w-full flex items-center justify-center">
+                    <span className="text-gray-500 dark:text-gray-400 text-sm">Loading editor...</span>
+                  </div>
+                }>
+                  <LazyMarkdownEditor
+                    value={notes}
+                    onChange={(value) => setNotes(value)}
+                    placeholder="Add a detailed description or note about this task..."
+                  />
+                </Suspense>
               </div>
             </div>
           </div>

--- a/src/components/TaskDetailSidebar.tsx
+++ b/src/components/TaskDetailSidebar.tsx
@@ -1,10 +1,17 @@
-import { useState, useEffect, useCallback, useRef, Suspense } from 'react';
+import React, { useState, useEffect, useCallback, useRef } from 'react';
 import { X, Star, Calendar, Repeat, FileText, CheckSquare, Sun, Bell, Copy, Pin, Archive, List } from 'lucide-react';
 import type { Task } from '../types/index.ts';
 import { useTaskStore } from '../stores/taskStore.ts';
 import { Button } from './ui/Button.tsx';
 import { Input } from './ui/Input.tsx';
-import { LazyMarkdownEditor } from './ui/MarkdownEditor.tsx';
+// Create lazy component for MarkdownEditor
+const LazyMarkdownEditor = React.lazy(() => 
+  import('./ui/MarkdownEditor.tsx').then(module => ({ 
+    default: module.MarkdownEditor 
+  }))
+);
+import { LazyWrapper } from './ui/ErrorBoundary.tsx';
+import { EditorLoadingWithTimeout } from './ui/LoadingWithTimeout.tsx';
 import { DateTimePicker } from './DateTimePicker.tsx';
 import { CategorySelector } from './CategorySelector.tsx';
 import { AutoSaveIndicator } from './ui/AutoSaveIndicator.tsx';
@@ -887,17 +894,16 @@ export function TaskDetailSidebar({ task, isOpen, onClose, mode, initialListId }
                   </div>
                   <span className="font-medium text-base text-gray-900 dark:text-white">Add note</span>
                 </div>
-                <Suspense fallback={
-                  <div className="animate-pulse bg-gray-100 dark:bg-gray-700 rounded-lg h-32 w-full flex items-center justify-center">
-                    <span className="text-gray-500 dark:text-gray-400 text-sm">Loading editor...</span>
-                  </div>
-                }>
+                <LazyWrapper
+                  fallback={<EditorLoadingWithTimeout />}
+                  context="markdown editor"
+                >
                   <LazyMarkdownEditor
                     value={notes}
                     onChange={(value) => setNotes(value)}
                     placeholder="Add a detailed description or note about this task..."
                   />
-                </Suspense>
+                </LazyWrapper>
               </div>
             </div>
           </div>

--- a/src/components/ui/ErrorBoundary.tsx
+++ b/src/components/ui/ErrorBoundary.tsx
@@ -1,0 +1,123 @@
+import React, { Component } from 'react';
+import type { ErrorInfo, ReactNode } from 'react';
+import { AlertTriangle, RefreshCw } from 'lucide-react';
+import { Button } from './Button.tsx';
+import { cn } from '../../utils/cn.ts';
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+  error?: Error;
+}
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+  fallback?: ReactNode;
+  className?: string;
+  onError?: (error: Error, errorInfo: ErrorInfo) => void;
+  showRetry?: boolean;
+  context?: string;
+}
+
+export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    console.error('ErrorBoundary caught an error:', error, errorInfo);
+    
+    // Call the optional error handler
+    if (this.props.onError) {
+      this.props.onError(error, errorInfo);
+    }
+  }
+
+  handleRetry = () => {
+    this.setState({ hasError: false, error: undefined });
+  };
+
+  render() {
+    if (this.state.hasError) {
+      // Use custom fallback if provided
+      if (this.props.fallback) {
+        return this.props.fallback;
+      }
+
+      // Default error UI
+      return (
+        <div className={cn(
+          'flex flex-col items-center justify-center p-6 text-center',
+          'bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-xl',
+          this.props.className
+        )}>
+          <div className="flex items-center justify-center w-12 h-12 mb-4 bg-red-100 dark:bg-red-900/30 rounded-full">
+            <AlertTriangle className="w-6 h-6 text-red-600 dark:text-red-400" />
+          </div>
+          
+          <h3 className="text-lg font-semibold text-red-900 dark:text-red-100 mb-2">
+            {this.props.context ? `Failed to load ${this.props.context}` : 'Something went wrong'}
+          </h3>
+          
+          <p className="text-sm text-red-700 dark:text-red-300 mb-4 max-w-md">
+            {this.state.error?.message || 'An unexpected error occurred while loading this component.'}
+          </p>
+
+          {this.props.showRetry !== false && (
+            <Button
+              onClick={this.handleRetry}
+              variant="secondary"
+              size="sm"
+              className="bg-white dark:bg-gray-800 border-red-200 dark:border-red-700 hover:bg-red-50 dark:hover:bg-red-900/30"
+            >
+              <RefreshCw className="w-4 h-4 mr-2" />
+              Try Again
+            </Button>
+          )}
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+// Enhanced wrapper for lazy components with timeout handling
+interface LazyWrapperProps {
+  children: ReactNode;
+  fallback?: ReactNode;
+  className?: string;
+  context?: string;
+  onRetry?: () => void;
+}
+
+export function LazyWrapper({ children, fallback, className, context, onRetry }: LazyWrapperProps) {
+  const [retryKey, setRetryKey] = React.useState(0);
+
+  const handleErrorBoundaryRetry = () => {
+    setRetryKey(prev => prev + 1);
+    onRetry?.();
+  };
+
+  return (
+    <ErrorBoundary 
+      key={retryKey} // Force remount on retry to reset lazy loading
+      className={className} 
+      context={context}
+      onError={(error) => {
+        // Log errors for debugging
+        console.error(`Lazy loading error in ${context}:`, error);
+        // Automatically trigger retry after error to reset state
+        setTimeout(handleErrorBoundaryRetry, 100);
+      }}
+    >
+      <React.Suspense fallback={fallback}>
+        {children}
+      </React.Suspense>
+    </ErrorBoundary>
+  );
+}

--- a/src/components/ui/LoadingPlaceholder.tsx
+++ b/src/components/ui/LoadingPlaceholder.tsx
@@ -1,0 +1,71 @@
+import { cn } from '../../utils/cn.ts';
+
+interface LoadingPlaceholderProps {
+  className?: string;
+  height?: string;
+  message?: string;
+  variant?: 'default' | 'minimal' | 'editor';
+}
+
+export function LoadingPlaceholder({ 
+  className, 
+  height = 'h-32', 
+  message = 'Loading...',
+  variant = 'default'
+}: LoadingPlaceholderProps) {
+  const getVariantStyles = () => {
+    switch (variant) {
+      case 'minimal':
+        return 'bg-transparent';
+      case 'editor':
+        return 'bg-gray-100 dark:bg-gray-700 rounded-lg';
+      default:
+        return 'bg-gray-50 dark:bg-gray-800/50 rounded-xl border border-gray-200 dark:border-gray-700';
+    }
+  };
+
+  return (
+    <div 
+      className={cn(
+        'w-full flex items-center justify-center transition-all duration-200',
+        height,
+        getVariantStyles(),
+        className
+      )}
+    >
+      <div className="flex items-center gap-3">
+        {/* Spinner */}
+        <div className="relative">
+          <div className="w-5 h-5 border-2 border-gray-300 dark:border-gray-600 border-t-blue-500 rounded-full animate-spin" />
+        </div>
+        
+        {/* Loading text */}
+        <span className="text-gray-500 dark:text-gray-400 text-sm font-medium">
+          {message}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+// Specific variants for common use cases
+export function EditorLoadingPlaceholder({ className, message = 'Loading editor...' }: Pick<LoadingPlaceholderProps, 'className' | 'message'>) {
+  return (
+    <LoadingPlaceholder 
+      variant="editor" 
+      className={className} 
+      message={message}
+    />
+  );
+}
+
+export function ModalLoadingPlaceholder({ className, message = 'Loading...' }: Pick<LoadingPlaceholderProps, 'className' | 'message'>) {
+  return (
+    <LoadingPlaceholder 
+      variant="minimal" 
+      height="h-auto" 
+      className={cn('py-4', className)} 
+      message={message}
+    />
+  );
+}

--- a/src/components/ui/LoadingWithTimeout.tsx
+++ b/src/components/ui/LoadingWithTimeout.tsx
@@ -1,0 +1,135 @@
+import { useState, useEffect } from 'react';
+import { AlertTriangle, RefreshCw } from 'lucide-react';
+import { LoadingPlaceholder } from './LoadingPlaceholder.tsx';
+import { Button } from './Button.tsx';
+import { cn } from '../../utils/cn.ts';
+
+interface LoadingWithTimeoutProps {
+  className?: string;
+  height?: string;
+  message?: string;
+  variant?: 'default' | 'minimal' | 'editor';
+  timeout?: number; // in milliseconds
+  onTimeout?: () => void;
+  onRetry?: () => void;
+  showRetry?: boolean;
+}
+
+export function LoadingWithTimeout({ 
+  className, 
+  height = 'h-32', 
+  message = 'Loading...',
+  variant = 'default',
+  timeout = 10000, // 10 seconds default
+  onTimeout,
+  onRetry,
+  showRetry = true
+}: LoadingWithTimeoutProps) {
+  const [hasTimedOut, setHasTimedOut] = useState(false);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setHasTimedOut(true);
+      onTimeout?.();
+    }, timeout);
+
+    return () => clearTimeout(timer);
+  }, [timeout, onTimeout]);
+
+  const handleRetry = () => {
+    setHasTimedOut(false);
+    onRetry?.();
+  };
+
+  if (hasTimedOut) {
+    const getVariantStyles = () => {
+      switch (variant) {
+        case 'minimal':
+          return 'bg-transparent border-0';
+        case 'editor':
+          return 'bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-lg';
+        default:
+          return 'bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-xl';
+      }
+    };
+
+    return (
+      <div 
+        className={cn(
+          'w-full flex flex-col items-center justify-center gap-3 p-4 transition-all duration-200',
+          height,
+          getVariantStyles(),
+          className
+        )}
+      >
+        <div className="flex items-center justify-center w-10 h-10 bg-amber-100 dark:bg-amber-900/30 rounded-full">
+          <AlertTriangle className="w-5 h-5 text-amber-600 dark:text-amber-400" />
+        </div>
+        
+        <div className="text-center">
+          <p className="text-sm font-medium text-amber-900 dark:text-amber-100 mb-1">
+            Taking longer than expected
+          </p>
+          <p className="text-xs text-amber-700 dark:text-amber-300">
+            The component may be slow to load or unavailable
+          </p>
+        </div>
+
+        {showRetry && onRetry && (
+          <Button
+            onClick={handleRetry}
+            variant="secondary"
+            size="sm"
+            className="bg-white dark:bg-amber-800 border-amber-200 dark:border-amber-700 hover:bg-amber-50 dark:hover:bg-amber-900/50 text-amber-900 dark:text-amber-100"
+          >
+            <RefreshCw className="w-3 h-3 mr-2" />
+            Try Again
+          </Button>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <LoadingPlaceholder 
+      className={className}
+      height={height}
+      message={message}
+      variant={variant}
+    />
+  );
+}
+
+// Specific variants for common use cases
+export function EditorLoadingWithTimeout({ 
+  className, 
+  message = 'Loading editor...',
+  onRetry 
+}: Pick<LoadingWithTimeoutProps, 'className' | 'message' | 'onRetry'>) {
+  return (
+    <LoadingWithTimeout 
+      variant="editor" 
+      className={className} 
+      message={message}
+      timeout={8000} // Shorter timeout for editor
+      onRetry={onRetry}
+    />
+  );
+}
+
+export function ModalLoadingWithTimeout({ 
+  className, 
+  message = 'Loading...',
+  onRetry 
+}: Pick<LoadingWithTimeoutProps, 'className' | 'message' | 'onRetry'>) {
+  return (
+    <LoadingWithTimeout 
+      variant="minimal" 
+      height="h-auto" 
+      className={cn('py-4', className)} 
+      message={message}
+      timeout={6000} // Shorter timeout for modals
+      onRetry={onRetry}
+    />
+  );
+}

--- a/src/components/ui/MarkdownEditor.tsx
+++ b/src/components/ui/MarkdownEditor.tsx
@@ -238,9 +238,4 @@ export function MarkdownEditor({
   );
 }
 
-// Lazy-loaded wrapper component
-export const LazyMarkdownEditor = React.lazy(() => 
-  import('./MarkdownEditor.tsx').then(module => ({ 
-    default: module.MarkdownEditor 
-  }))
-);
+

--- a/src/components/ui/MarkdownEditor.tsx
+++ b/src/components/ui/MarkdownEditor.tsx
@@ -237,3 +237,10 @@ export function MarkdownEditor({
     </div>
   );
 }
+
+// Lazy-loaded wrapper component
+export const LazyMarkdownEditor = React.lazy(() => 
+  import('./MarkdownEditor.tsx').then(module => ({ 
+    default: module.MarkdownEditor 
+  }))
+);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,4 +4,28 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  build: {
+    rollupOptions: {
+      output: {
+        manualChunks: {
+          // React core
+          'react-vendor': ['react', 'react-dom'],
+          
+          // UI Libraries
+          'ui-vendor': ['lucide-react', '@dnd-kit/core', '@dnd-kit/sortable', '@dnd-kit/utilities'],
+          
+          // Date utilities
+          'date-vendor': ['date-fns'],
+          
+          // Markdown (large dependency, used conditionally)
+          'markdown-vendor': ['react-markdown', 'remark-gfm'],
+          
+          // State management and utilities
+          'utils-vendor': ['zustand', 'clsx', 'tailwind-merge', 'uuid']
+        }
+      }
+    },
+    // Increase chunk size warning limit slightly for vendor chunks
+    chunkSizeWarningLimit: 600
+  }
 })


### PR DESCRIPTION
This pull request introduces code-splitting and lazy-loading for modal and markdown editor components to optimize the application's performance and initial load time. Additionally, it updates the build configuration to split vendor dependencies into separate chunks for more efficient loading. The most important changes are grouped below:

**Performance Optimization: Lazy-loading Components**

* The `GroupEditModal` component is now lazy-loaded as `LazyGroupEditModal` using React's `Suspense`, reducing the initial bundle size and only loading the modal when needed. (`src/App.tsx`, `src/components/GroupEditModal.tsx`) [[1]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2L1-R5) [[2]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2L40-R45) [[3]](diffhunk://#diff-7ff0ac41589e67404346706a6cb785d19109e87af701b593a77709eae421668eR169-R175)
* The `MarkdownEditor` component is now lazy-loaded as `LazyMarkdownEditor` with a loading fallback UI, improving performance when opening the task detail sidebar. (`src/components/TaskDetailSidebar.tsx`, `src/components/ui/MarkdownEditor.tsx`) [[1]](diffhunk://#diff-ebff03fe2c65d63b65ae073be9e858bb80ba9fcdbf8b945ed9f030d37a309ac8L1-R7) [[2]](diffhunk://#diff-ebff03fe2c65d63b65ae073be9e858bb80ba9fcdbf8b945ed9f030d37a309ac8L890-R900) [[3]](diffhunk://#diff-35d0d403764a73ce04769debab34b5c68ffe53b709dd8c4115cf8ad6cdc611ffR240-R246)

**Build Configuration: Vendor Chunk Splitting**

* The Vite build configuration is updated to manually split vendor libraries (React, UI libraries, date utilities, markdown, state management, and utilities) into separate chunks for better caching and reduced initial load times. The chunk size warning limit is also increased to accommodate larger vendor chunks. (`vite.config.ts`)Introduces React.lazy wrappers for GroupEditModal and MarkdownEditor components, enabling code splitting and lazy loading via Suspense. Updates App and TaskDetailSidebar to use the lazy-loaded versions. Vite config is updated to manually split vendor chunks for improved build performance and chunk management.

## Summary by Sourcery

Implement code-splitting by lazy-loading the GroupEditModal and MarkdownEditor components with Suspense and update the Vite config to split vendor dependencies into distinct chunks for improved performance

New Features:
- Lazy-load the GroupEditModal component using React.lazy and Suspense
- Lazy-load the MarkdownEditor component with a loading fallback via React.lazy and Suspense

Enhancements:
- Update Vite build configuration to manually split vendor libraries into separate chunks
- Increase the chunk size warning limit for vendor chunks to 600 KB