### PR TITLE
Add spacer to prevent FAB overlap in TaskList

### DIFF
--- a/src/components/TaskList.tsx
+++ b/src/components/TaskList.tsx
@@ -123,7 +123,7 @@ export function TaskList() {
   };
 
   return (
-    <div className="p-6 w-full">
+    <div className="p-6 w-full relative">
       {/* No Tasks Message */}
       {allTasks.length === 0 ? (
         <div className="flex flex-col items-center justify-center h-48 text-gray-500 dark:text-gray-400">
@@ -213,6 +213,16 @@ export function TaskList() {
             </div>
           )}
         </>
+      )}
+      
+      {/* Global spacer to prevent FAB overlap - always present regardless of task list state */}
+      {allTasks.length > 0 && (
+        <div 
+          className="h-16 sm:h-20" 
+          aria-hidden="true"
+          data-testid="fab-spacer"
+          title="Space to prevent floating action button overlap"
+        />
       )}
     </div>
   );


### PR DESCRIPTION
This pull request makes a small UI improvement to the `TaskList` component to ensure that the floating action button (FAB) does not overlap with the task list content. A spacer element is added at the bottom of the list when tasks are present.

UI improvements:

* Added a spacer `<div>` with a fixed height at the bottom of the `TaskList` to prevent overlap with the FAB when tasks are present. (`src/components/TaskList.tsx`)
* Updated the root container `<div>` to use `relative` positioning, supporting the new spacer and FAB layout. (`src/components/TaskList.tsx`)Introduces a global spacer div at the bottom of the TaskList component when tasks are present. This ensures the floating action button does not overlap with task content, improving usability on all screen sizes.

## Summary by Sourcery

Prevent the floating action button (FAB) from overlapping task content in the TaskList component by adding a bottom spacer and adjusting container positioning

Enhancements:
- Make the TaskList root container relatively positioned to support the new spacer layout
- Insert a conditional spacer div at the bottom of the task list when tasks are present to reserve space for the FAB